### PR TITLE
Enable caching for CC and CXX

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Build
         env:
-          AWS_ACCESS_KEY_ID: {{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: {{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           python3 build-locally.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,4 +22,4 @@ jobs:
         with:
           name: packages
           path: |
-            build_artifacts/*
+            build_artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,10 +6,10 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-  steps:
-    - name: Build
-      env:
-        AWS_ACCESS_KEY_ID: {{ secrets.AWS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: {{ secrets.AWS_SECRET_ACCESS_KEY }}
-      run: |
-        python3 build-locally.py
+    steps:
+      - name: Build
+        env:
+          AWS_ACCESS_KEY_ID: {{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: {{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: |
+          python3 build-locally.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,15 @@
+name: Build
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+  steps:
+    - name: Build
+      env:
+        AWS_ACCESS_KEY_ID: {{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: {{ secrets.AWS_SECRET_ACCESS_KEY }}
+      run: |
+        python3 build-locally.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,3 +17,9 @@ jobs:
           SCCACHE_REGION: ${{ vars.SCCACHE_REGION }}
         run: |
           python3 build-locally.py
+      - name: Archive package artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: packages
+          path: |
+            build_artifacts/*

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,5 +13,7 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          SCCACHE_BUCKET: ${{ vars.SCCACHE_BUCKET }}
+          SCCACHE_REGION: ${{ vars.SCCACHE_REGION }}
         run: |
           python3 build-locally.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: checkout
+        uses: actions/checkout@v3
       - name: Build
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 # Don't ignore any files/folders recursively in the following folders
 !/recipe/**
 !/.ci_support/**
+!/.github/workflows/build.yml
 
 # Since we ignore files/folders recursively, any folders inside
 # build_artifacts gets ignored which trips some build systems.

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -65,6 +65,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
+	echo "---------- Bucket: $SCCACHE_BUCKET"
     conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
 	--no-test \
         --no-build-id \

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -65,9 +65,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-	echo "---------- Bucket: $SCCACHE_BUCKET"
     conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
-	--no-test \
         --no-build-id \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -66,6 +66,8 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     /bin/bash
 else
     conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+	--no-test \
+        --no-build-id \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -80,6 +80,8 @@ fi
 
 ( startgroup "Start Docker" ) 2> /dev/null
 
+echo "========= Bucket: $SCCACHE_BUCKET"
+
 export UPLOAD_PACKAGES="${UPLOAD_PACKAGES:-True}"
 export IS_PR_BUILD="${IS_PR_BUILD:-False}"
 docker pull "${DOCKER_IMAGE}"
@@ -101,6 +103,12 @@ docker run ${DOCKER_RUN_ARGS} \
            -e remote_url \
            -e sha \
            -e BINSTAR_TOKEN \
+           -e SCCACHE_BUCKET \
+           -e SCCACHE_REGION \
+           -e SCCACHE_ENDPOINT \
+           -e SCCACHE_S3_USE_SSL \
+           -e AWS_ACCESS_KEY_ID \
+           -e AWS_SECRET_ACCESS_KEY \
            "${DOCKER_IMAGE}" \
            bash \
            "/home/conda/feedstock_root/${PROVIDER_DIR}/build_steps.sh"

--- a/recipe/build-tiledb-py.sh
+++ b/recipe/build-tiledb-py.sh
@@ -7,5 +7,9 @@ source $RECIPE_DIR/enable-caching.sh
 
 export TILEDB_CONDA_BUILD=1
 
+sccache -z
+
 cd TileDB-Py/
 $PYTHON setup.py install --tiledb="$PREFIX" --single-version-externally-managed --record record.txt
+
+sccache -s

--- a/recipe/build-tiledb-py.sh
+++ b/recipe/build-tiledb-py.sh
@@ -3,6 +3,8 @@
 set -e
 set -x
 
+source $RECIPE_DIR/enable-caching.sh
+
 export TILEDB_CONDA_BUILD=1
 
 cd TileDB-Py/

--- a/recipe/build-tiledb-r.sh
+++ b/recipe/build-tiledb-r.sh
@@ -1,6 +1,8 @@
 set -x
 set -o xtrace
 
+source $RECIPE_DIR/enable-caching.sh
+
 cd TileDB-R/
 
 ## Build a tarball and install from the tarball is the officially blessed way

--- a/recipe/build-tiledb-r.sh
+++ b/recipe/build-tiledb-r.sh
@@ -5,7 +5,11 @@ source $RECIPE_DIR/enable-caching.sh
 
 cd TileDB-R/
 
+sccache -z
+
 ## Build a tarball and install from the tarball is the officially blessed way
 ## It has also respects the .Rbuildignore file allowing us to fine-tune
 $R CMD build --no-manual --no-build-vignettes .
 $R CMD INSTALL --configure-args=--with-tiledb=${CONDA_PREFIX} --install-tests --build tiledb_*.tar.gz ${R_ARGS}
+
+sccache -s

--- a/recipe/build-tiledb-soma-py.sh
+++ b/recipe/build-tiledb-soma-py.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+source $RECIPE_DIR/enable-caching.sh
+
 cd TileDB-SOMA/
 
 cd apis/python

--- a/recipe/build-tiledb-soma-py.sh
+++ b/recipe/build-tiledb-soma-py.sh
@@ -8,7 +8,11 @@ cd TileDB-SOMA/
 
 cd apis/python
 
+sccache -z
+
 echo "$PKG_VERSION" >> RELEASE-VERSION
 $PYTHON setup.py install --single-version-externally-managed --record record.txt --libtiledbsoma="${PREFIX}"
 
 $PYTHON setup.py clean --all
+
+sccache -s

--- a/recipe/build-tiledb-soma-r.sh
+++ b/recipe/build-tiledb-soma-r.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+source $RECIPE_DIR/enable-caching.sh
+
 cd TileDB-SOMA/
 
 cd apis/r

--- a/recipe/build-tiledb-soma-r.sh
+++ b/recipe/build-tiledb-soma-r.sh
@@ -8,6 +8,8 @@ cd TileDB-SOMA/
 
 cd apis/r
 
+sccache -z
+
 export DISABLE_AUTOBREW=1
 
 # https://github.com/conda-forge/r-tiledb-feedstock/commit/29cb6816636e7b5b58545e1407a8f0c29ff9dc39
@@ -37,3 +39,5 @@ if [[ $target_platform  == osx-arm64 ]]; then
 fi
 
 ${R} CMD INSTALL ${R_ARGS_EXTRA} --build . ${R_ARGS}
+
+sccache -s

--- a/recipe/build-tiledb-soma.sh
+++ b/recipe/build-tiledb-soma.sh
@@ -6,6 +6,8 @@ source $RECIPE_DIR/enable-caching.sh
 
 cd TileDB-SOMA/
 
+sccache -z
+
 mkdir libtiledbsoma-build && cd libtiledbsoma-build
 
 cmake \
@@ -21,3 +23,5 @@ make -j ${CPU_COUNT}
 make install-libtiledbsoma
 
 cd .. && rm -rf libtiledbsoma-build
+
+sccache -s

--- a/recipe/build-tiledb-soma.sh
+++ b/recipe/build-tiledb-soma.sh
@@ -2,6 +2,8 @@
 
 set -exo pipefail
 
+source $RECIPE_DIR/enable-caching.sh
+
 cd TileDB-SOMA/
 
 mkdir libtiledbsoma-build && cd libtiledbsoma-build

--- a/recipe/build-tiledb-vcf-py.sh
+++ b/recipe/build-tiledb-vcf-py.sh
@@ -8,8 +8,10 @@ cd TileDB-VCF/
 
 cd apis/python
 
+sccache -z
+
 $PYTHON setup.py install --single-version-externally-managed --record record.txt --libtiledbvcf="${PREFIX}"
 
 $PYTHON setup.py clean --all
 
-ccache -s
+sccache -s

--- a/recipe/build-tiledb-vcf-py.sh
+++ b/recipe/build-tiledb-vcf-py.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
+source $RECIPE_DIR/enable-caching.sh
+
 cd TileDB-VCF/
 
 cd apis/python
@@ -9,3 +11,5 @@ cd apis/python
 $PYTHON setup.py install --single-version-externally-managed --record record.txt --libtiledbvcf="${PREFIX}"
 
 $PYTHON setup.py clean --all
+
+ccache -s

--- a/recipe/build-tiledb-vcf.sh
+++ b/recipe/build-tiledb-vcf.sh
@@ -6,6 +6,8 @@ source $RECIPE_DIR/enable-caching.sh
 
 cd TileDB-VCF/
 
+sccache -z
+
 mkdir libtiledbvcf-build && cd libtiledbvcf-build
 
 cmake \
@@ -21,3 +23,5 @@ make install-libtiledbvcf
 
 # Cleanup
 cd ../ && rm -r libtiledbvcf-build
+
+sccache -s

--- a/recipe/build-tiledb-vcf.sh
+++ b/recipe/build-tiledb-vcf.sh
@@ -2,6 +2,8 @@
 
 set -exo pipefail
 
+source $RECIPE_DIR/enable-caching.sh
+
 cd TileDB-VCF/
 
 mkdir libtiledbvcf-build && cd libtiledbvcf-build

--- a/recipe/build-tiledb.sh
+++ b/recipe/build-tiledb.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -exo pipefail
 
+source $RECIPE_DIR/enable-caching.sh
+
 cd TileDB/
 
 CURL_LIBS_APPEND=`$PREFIX/bin/curl-config --libs`
@@ -27,3 +29,5 @@ cmake ${CMAKE_ARGS} \
   ..
 make -j ${CPU_COUNT}
 make -C tiledb install
+
+ccache -s

--- a/recipe/build-tiledb.sh
+++ b/recipe/build-tiledb.sh
@@ -10,6 +10,8 @@ export LDFLAGS="${LDFLAGS} ${CURL_LIBS_APPEND}"
 export LDFLAGS="${LDFLAGS} -Wl,--no-as-needed -lrt"
 export TILEDB_GCS=ON
 
+sccache -z
+
 mkdir build && cd build
 cmake ${CMAKE_ARGS} \
   -DTILEDB_VCPKG=OFF \
@@ -30,4 +32,4 @@ cmake ${CMAKE_ARGS} \
 make -j ${CPU_COUNT}
 make -C tiledb install
 
-ccache -s
+sccache -s

--- a/recipe/cc_wrap.sh
+++ b/recipe/cc_wrap.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 args="${@##-Werror*}"
-ccache $NN_CC_ORIG $args
+sccache $NN_CC_ORIG $args

--- a/recipe/cc_wrap.sh
+++ b/recipe/cc_wrap.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+args="${@##-Werror*}"
+ccache $NN_CC_ORIG $args

--- a/recipe/cxx_wrap.sh
+++ b/recipe/cxx_wrap.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+args="${@##-Werror*}"
+ccache $NN_CXX_ORIG $args

--- a/recipe/cxx_wrap.sh
+++ b/recipe/cxx_wrap.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 args="${@##-Werror*}"
-ccache $NN_CXX_ORIG $args
+sccache $NN_CXX_ORIG $args

--- a/recipe/enable-caching.sh
+++ b/recipe/enable-caching.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+export CCACHE_DIR=/home/conda/feedstock_root/.ccache
+
+export NN_CXX_ORIG=$CXX
+export NN_CC_ORIG=$CC
+export CXX=$RECIPE_DIR/cxx_wrap.sh
+export CC=$RECIPE_DIR/cc_wrap.sh
+
+# export CC="ccache ${CC}"
+# export CXX="ccache ${CXX}"
+# export CMAKE_C_COMPILER_LAUNCHER="ccache"
+# export CMAKE_CXX_COMPILER_LAUNCHER="ccache"
+# export CCACHE_BASEDIR="${SRC_DIR}"

--- a/recipe/enable-caching.sh
+++ b/recipe/enable-caching.sh
@@ -6,3 +6,7 @@ export NN_CXX_ORIG=$CXX
 export NN_CC_ORIG=$CC
 export CXX=$RECIPE_DIR/cxx_wrap.sh
 export CC=$RECIPE_DIR/cc_wrap.sh
+
+mkdir -p ~/.R
+echo -e "CC=$CC\nCXX=$CXX\nCXX14=$CXX\nCXX17=$CXX\nCXX20=$CXX\n" > ~/.R/Makevars
+cat ~/.R/Makevars

--- a/recipe/enable-caching.sh
+++ b/recipe/enable-caching.sh
@@ -1,14 +1,8 @@
 #!/bin/sh
 
-export CCACHE_DIR=/home/conda/feedstock_root/.ccache
+echo "sccache bucket: $SCCACHE_BUCKET"
 
 export NN_CXX_ORIG=$CXX
 export NN_CC_ORIG=$CC
 export CXX=$RECIPE_DIR/cxx_wrap.sh
 export CC=$RECIPE_DIR/cc_wrap.sh
-
-# export CC="ccache ${CC}"
-# export CXX="ccache ${CXX}"
-# export CMAKE_C_COMPILER_LAUNCHER="ccache"
-# export CMAKE_CXX_COMPILER_LAUNCHER="ccache"
-# export CCACHE_BASEDIR="${SRC_DIR}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,7 @@ outputs:
         - {{ pin_subpackage('tiledb', max_pin='x.x') }}
     requirements:
       build:
+        - ccache
         - make
         - cmake
         - pkg-config
@@ -106,6 +107,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
+        - ccache
       host:
         - pip
         - wheel
@@ -163,6 +165,7 @@ outputs:
         - {{ compiler('cxx') }}
         - pkg-config
         - make
+        - ccache
       host:
         - r-base
         - {{ pin_subpackage('tiledb', exact=True) }}
@@ -205,6 +208,7 @@ outputs:
         - git
         - cmake
         - make
+        - ccache
       host:
         - htslib >=1.15
         - {{ pin_subpackage('tiledb', exact=True) }}
@@ -228,6 +232,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
+        - ccache
       host:
         - numpy
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
@@ -269,6 +274,7 @@ outputs:
         - git
         - cmake
         - make
+        - ccache
       host:
         - {{ pin_subpackage('tiledb', exact=True) }}
         - spdlog
@@ -296,6 +302,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
+        - ccache
       host:
         - python
         - pip
@@ -354,6 +361,7 @@ outputs:
       build:
         - {{ compiler('cxx') }}
         - pkg-config
+        - ccache
       host:
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - r-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 # Set versions here ----
 
 # TileDB
-{% set version_tiledb = "2.19.1" %}
-{% set git_rev_tiledb = "2.19.1" %}
+{% set version_tiledb = "2.19.0" %}
+{% set git_rev_tiledb = "2.19.0" %}
 
 # TileDB-Py
 {% set version_tiledb_py = "0.24.0" %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 # Set versions here ----
 
 # TileDB
-{% set version_tiledb = "2.18.4" %}
-{% set git_rev_tiledb = "2.18.4" %}
+{% set version_tiledb = "2.19.1" %}
+{% set git_rev_tiledb = "2.19.1" %}
 
 # TileDB-Py
 {% set version_tiledb_py = "0.24.0" %}
@@ -49,12 +49,19 @@ outputs:
     script: build-tiledb.sh
     build:
       number: 0
+      script_env:
+        - SCCACHE_BUCKET
+        - SCCACHE_REGION
+          # - SCCACHE_ENDPOINT
+          # - SCCACHE_S3_USE_SSL
+        - AWS_ACCESS_KEY_ID
+        - AWS_SECRET_ACCESS_KEY
       run_exports:
         # https://abi-laboratory.pro/?view=timeline&l=tiledb
         - {{ pin_subpackage('tiledb', max_pin='x.x') }}
     requirements:
       build:
-        - ccache
+        - sccache
         - make
         - cmake
         - pkg-config
@@ -107,7 +114,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
-        - ccache
+        - sccache
       host:
         - pip
         - wheel
@@ -165,7 +172,7 @@ outputs:
         - {{ compiler('cxx') }}
         - pkg-config
         - make
-        - ccache
+        - sccache
       host:
         - r-base
         - {{ pin_subpackage('tiledb', exact=True) }}
@@ -208,7 +215,7 @@ outputs:
         - git
         - cmake
         - make
-        - ccache
+        - sccache
       host:
         - htslib >=1.15
         - {{ pin_subpackage('tiledb', exact=True) }}
@@ -232,7 +239,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
-        - ccache
+        - sccache
       host:
         - numpy
         - {{ pin_subpackage('libtiledbvcf', exact=True) }}
@@ -274,7 +281,7 @@ outputs:
         - git
         - cmake
         - make
-        - ccache
+        - sccache
       host:
         - {{ pin_subpackage('tiledb', exact=True) }}
         - spdlog
@@ -302,7 +309,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
-        - ccache
+        - sccache
       host:
         - python
         - pip
@@ -361,7 +368,7 @@ outputs:
       build:
         - {{ compiler('cxx') }}
         - pkg-config
-        - ccache
+        - sccache
       host:
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - r-base


### PR DESCRIPTION
These changes add ccache to all compilation commands. After the cache is build it decreases the build time to around 13 minutes on 64 core device